### PR TITLE
Update script tags to point to new paths for jquery-ui and angular-ui-date

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ To your `components.json` file. Then run
 This will copy the ui-date files into your `components` folder, along with its dependencies. Load the script files in your application:
 
     <script type="text/javascript" src="components/jquery/jquery.js"></script>
-    <script type="text/javascript" src="components/jquery-ui\ui\jquery-ui.custom.js"></script>
+    <script type="text/javascript" src="components/jquery-ui/ui/jquery-ui.js"></script>
     <script type="text/javascript" src="components/angular/angular.js"></script>
-    <script type="text/javascript" src="components/angular-ui-date/date.js"></script>
+    <script type="text/javascript" src="components/angular-ui-date/src/date.js"></script>
 
 Add the date module as a dependency to your application module:
 


### PR DESCRIPTION
Hey, thanks for this great project. 

I just tried to setup a new project using the "Usage" section from the readme and I noticed the bower script tags currently listed point to the wrong path. 
