### PR TITLE
Stop resetting time info to midnight on update

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -25,6 +25,25 @@ angular.module('ui.date', [])
         var showing = false;
         var opts = getOptions();
 
+        function setVal() {
+          var keys = ['Hours', 'Minutes', 'Seconds', 'Milliseconds'],
+              isDate = angular.isDate(controller.$modelValue),
+              preserve = {};
+
+          if (isDate) {
+            angular.forEach(keys, function(key) {
+              preserve[key] = controller.$modelValue['get' + key]();
+            });
+          }
+          controller.$setViewValue(element.datepicker('getDate'));
+
+          if (isDate) {
+            angular.forEach(keys, function(key) {
+               controller.$viewValue['set' + key](preserve[key]);
+            });
+          }
+        }
+
         // If we have a controller (i.e. ngModelController) then wire it up
         if (controller) {
 
@@ -34,7 +53,7 @@ angular.module('ui.date', [])
           opts.onSelect = function (value, picker) {
             scope.$apply(function() {
               showing = true;
-              controller.$setViewValue(element.datepicker('getDate'));
+              setVal();
               _onSelect(value, picker);
               element.blur();
             });
@@ -55,7 +74,7 @@ angular.module('ui.date', [])
             if ( !showing ) {
               scope.$apply(function() {
                 element.datepicker('setDate', element.datepicker('getDate'));
-                controller.$setViewValue(element.datepicker('getDate'));
+                setVal();
               });
             }
           });

--- a/test/date.spec.js
+++ b/test/date.spec.js
@@ -105,6 +105,16 @@ describe('uiDate', function() {
       });
   });
 
+  it('should preserve time', function() {
+    inject(function($compile, $rootScope) {
+      $rootScope.x = new Date(2012,9,12,15);
+      var element = $compile('<input ui-date ng-model="x"/>')($rootScope);
+      $rootScope.$apply();
+      selectDate(element, $rootScope.x);
+      expect($rootScope.x.getHours()).toBe(15);
+    });
+  });
+
   describe('jQuery widget', function() {
     var element;
 


### PR DESCRIPTION
I'm using `uiDate` in a context where the model value is also bound to a UI Bootstrap `timepicker`. I noticed that the time data was getting killed every time the date would update. This patch fixes it.

The fix isn't the cleanest thing I've ever written, but if somebody's got something better, I will be the first to disown this.