### PR TITLE
Handle integer timestamp

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -89,14 +89,20 @@ angular.module('ui.date', [])
       if ( dateFormat ) {
         // Use the datepicker with the attribute value as the dateFormat string to convert to and from a string
         modelCtrl.$formatters.push(function(value) {
-          if (angular.isString(value) ) {
+          if (angular.isString(value) || (angular.isNumber(value) && dateFormat === "@") ) {
             return jQuery.datepicker.parseDate(dateFormat, value);
           }
           return null;
         });
         modelCtrl.$parsers.push(function(value){
+          var returnValue = value;
           if (value) {
-            return jQuery.datepicker.formatDate(dateFormat, value);
+            returnValue = jQuery.datepicker.formatDate(dateFormat, value);
+            if (returnValue.match(/^\d+$/)) {
+              return parseInt(returnValue, 10);
+            } else {
+              return returnValue;
+            }
           }
           return null;
         });


### PR DESCRIPTION
Handle integer timestamp, read the timestamp correctly and if the result
is timestamp return it as integer.

We have an object which has integer timestamps, the directive would break when trying to bind on it directly.