### PR TITLE
Cleanup previously installed blur listeners.

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -45,6 +45,7 @@ angular.module('ui.date', [])
           opts.onClose = function(value, picker) {
             showing = false;
           };
+          element.off('blur');
           element.on('blur', function() {
             if ( !showing ) {
               scope.$apply(function() {


### PR DESCRIPTION
Because this is causing me problems if I change the date format dynamically. The change is picked up correctly and the date picker is recreated but I cannot select a date in the date picker because the old blur listener kicks in before any other handler.
