### PR TITLE
Old blur handler isn't removed removed when datepicker options change.

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -45,6 +45,7 @@ angular.module('ui.date', [])
           opts.onClose = function(value, picker) {
             showing = false;
           };
+          element.off('blur');
           element.on('blur', function() {
             if ( !showing ) {
               scope.$apply(function() {


### PR DESCRIPTION
The issue is evident here:

http://plnkr.co/edit/xVPSbgKDjrbNc6g4XiZN?p=preview

if you change the date in the first datepicker, the second one becomes completely non-functional in Chrome and somewhat broken in Firefox (you have to click twice to get the value to change and get an '$apply already in progress exception')
