### PR TITLE
Changed the "destroy-create" logic in the initDateWidget function.

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -63,13 +63,13 @@ angular.module('ui.date', [])
             element.datepicker("setDate", date);
           };
         }
-        // Verify if the element already have a datepicker. 
+        // Check if the element already has a datepicker. 
         if (element.data('datepicker')) {
             // Updates the datepicker options
             element.datepicker('option', opts);
             element.datepicker('refresh');
         } else
-            // Create the new datepicker widget
+            // Creates the new datepicker widget
             element.datepicker(opts);
             
         if ( controller ) {


### PR DESCRIPTION
Changed the "destroy-create" logic to a more classy and bug-free "create-or-update" logic in the initDateWidget function. The first one was giving me an error whenever I needed to update the options object (with or without angular's two-way data-binding). The second aproach corrected this bug keeping the original functionality of fully updating the widget.
