### PR TITLE
ignore bower_components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 components/
 node_modules/
+bower_components/


### PR DESCRIPTION
I'm not sure if I missed something when installing the repo.. But `bower_components/` wasn't in the `.gitignore`.
