### PR TITLE
Validate the date object using the modelValue

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -56,7 +56,7 @@ angular.module('ui.date', [])
 
           // Update the date picker when the model changes
           controller.$render = function () {
-            var date = controller.$viewValue;
+            var date = controller.$modelValue;
             if ( angular.isDefined(date) && date !== null && !angular.isDate(date) ) {
               throw new Error('ng-Model value must be a Date object - currently it is a ' + typeof date + ' - use ui-date-format to convert it from a string');
             }


### PR DESCRIPTION
This fixes one of the two tests that fail when switching to angular#1.3.0-rc.2.  The viewValue returns a string value each time but the modelValue returns the object version. See the [docs](https://docs.angularjs.org/api/ng/type/ngModel.NgModelController).  The tests also pass for angular 1.2.25.
