### PR TITLE
fix(ui-date): update to work with 1.3.x

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -82,7 +82,7 @@ angular.module('ui.date', [])
   };
 }
 ])
-.service('uiDateConverter', ['uiDateFormatConfig', function(uiDateFormatConfig){
+.factory('uiDateConverter', ['uiDateFormatConfig', function(uiDateFormatConfig){
 
     function dateToString(dateFormat, value){
         if (value) {


### PR DESCRIPTION
This incorporates #94 as well the fixes from #96 as suggested by @giannisp and currently removes the blur as suggested in #95.  I believe the switch to use modelValue is necessary if we are comparing it against a date as the angular docs say that viewValue should be a string.

This at least passes all tests using 1.3.0 and 1.2.5 however I am still concerned that we are removing the blur to workaround what might be related to issue angular/angular.js#8762.

Still I am submitting this to hopefully get closer to a full solution and this full pull request will at least pass all the tests.  If someone has some suggestions on a good test case for when we need the blur that would be great and we can enhance this further.
