### PR TITLE
Allow directives that convert the date before it is written to the model / read from the model

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -62,12 +62,11 @@ angular.module('ui.date', [])
 
           // Update the date picker when the model changes
           controller.$render = function () {
-            var date = controller.$modelValue;
+            var date = controller.$viewValue;
             if ( angular.isDefined(date) && date !== null && !angular.isDate(date) ) {
-                if ( angular.isString(controller.$modelValue) ) {
-                    date = uiDateConverter.stringToDate(attrs.uiDateFormat, controller.$modelValue);
-                } else {
-                    throw new Error('ng-Model value must be a Date, or a String object with a date formatter - currently it is a ' + typeof date + ' - use ui-date-format to convert it from a string');
+                date = uiDateConverter.stringToDate(attrs.uiDateFormat, date);
+                if ( date == null ) {
+                    throw new Error('ng-Model value must be a Date, or a String object with a date formatter - currently it is a ' + typeof date + ' and contains ' + date + ' - use ui-date-format to convert it from a string');
                 }
             }
             element.datepicker('setDate', date);

--- a/test/date.spec.js
+++ b/test/date.spec.js
@@ -76,6 +76,13 @@ describe('uiDate', function() {
         });
       }).toThrow();
     });
+    it('should throw an error if you try to pass in a string when the model is not set to a date string', function() {
+      expect(function() {
+        scope.$apply(function() {
+          scope.x = "not_a_date";
+        });
+      }).toThrow();
+    });
   });
 
   it('should update the input field correctly on a manual update', function() {


### PR DESCRIPTION
Use the $viewValue instead of the $modelValue.
This change allows us to add directives that change the value before persisting / reading from the model. Those changes are represented in the $viewValue and not in the $modelValue.