### PR TITLE
focus date field after date selected

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -50,6 +50,7 @@ angular.module('ui.date', [])
           opts.onClose = function(value, picker) {
             showing = false;
             _onClose(value, picker);
+            element.focus();
           };
           element.off('blur.datepicker').on('blur.datepicker', function() {
             if ( !showing ) {


### PR DESCRIPTION
So we've been building this system where we large forms and users are expected to tab through them very quickly with 'Tab'. However, the date fields are loosing focus once date is selected. When user selects date, and hits 'Tab' to go to next form element, the iteration starts over from first form element on the form.

This is not intended behavior in our use case, and I can imagine others having the same usability problem.

The solution we figured out, is simple, yet gets the job done: focus the input aftere date was selected.

I think it is the expected behavior from uses' point of view. They click within an input field, the field is expected to be focused after they fill in the date manually, or choose it from the drop-down.

If you agree with my ponint of view, would be great if you could merge that little change :).