### PR TITLE
Don't trigger a change if the date didn't actually change

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -30,6 +30,10 @@ angular.module('ui.date', [])
               isDate = angular.isDate(controller.$modelValue),
               preserve = {};
 
+          if(isDate && controller.$modelValue.toDateString() === element.datepicker('getDate').toDateString()) {
+            return;
+          }
+
           if (isDate) {
             angular.forEach(keys, function(key) {
               preserve[key] = controller.$modelValue['get' + key]();

--- a/test/date.spec.js
+++ b/test/date.spec.js
@@ -35,6 +35,21 @@ describe('uiDate', function() {
         expect($rootScope.x).toEqual(aDate);
       });
     });
+    it('should not trigger a ng-change when nothing changes', function() {
+      inject(function($compile, $rootScope) {
+        var aDate, element;
+        aDate = new Date(2010, 12, 1);
+        element = $compile('<input ui-date ng-model="x" />')($rootScope);
+        $rootScope.$apply(function() {
+          $rootScope.x = aDate;
+        });
+        var cur = $rootScope.x;
+        element.focus();
+        element.blur();
+
+        expect($rootScope.x).toBe(cur);
+      });
+    });
     it('should hide the date picker after selecting a date', function() {
       inject(function($compile, $rootScope) {
         var aDate, element;


### PR DESCRIPTION
This PR is to make sure that the model is not changed when the date is not changed. Currently when you focus/blur the datepicker (for example by clicking on the input, and then tabbing out), you still get a ng-change triggered.