### PR TITLE
Pass along the uiDateFormat option to the jQuery UI Datepicker plugin…

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -19,7 +19,9 @@ angular.module('ui.date', [])
     require:'?ngModel',
     link:function (scope, element, attrs, controller) {
       var getOptions = function () {
-        return angular.extend({}, uiDateConfig, scope.$eval(attrs.uiDate));
+        var opts = {};
+        if(attrs.uiDateFormat) opts.dateFormat = attrs.uiDateFormat;
+        return angular.extend(opts, uiDateConfig, scope.$eval(attrs.uiDate));
       };
       var initDateWidget = function () {
         var showing = false;


### PR DESCRIPTION
Currently users see jQuery Datepicker's default format in the input element, while our $scope gets the format we specified in uiDateFormat.

This PR makes the input element display the correct format too.
