### PR TITLE
Hide datepicker on route change

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -107,6 +107,7 @@ angular.module('ui.date', [])
 
             //Cleanup on destroy, prevent memory leaking
             element.on('$destroy', function () {
+               element.datepicker('hide');
                element.datepicker('destroy');
             });
         }


### PR DESCRIPTION
When datepicker is open and you click the back arrow in your browser
the datepicker would still be open, fixes #128.