### PR TITLE
Ui date fix date parrse and refactor

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "package.json"
   ],
   "dependencies": {
-    "angular": "^1.3.x",
-    "jquery-ui": "^1.9"
+    "angular": "~1.5.x",
+    "jquery-ui": "~1.11"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -16,40 +16,28 @@
 
     <h2>ui-date (binding options)</h2>
     <fieldset>
-      <!--<label for="date">Select Date:</label>-->
-      <!--<input type="text" id="date" ui-date="dateOptions" ng-model="aDate">-->
+      <label for="date">Select Date:</label>
+      <input type="text" id="date" ui-date="dateOptions" ng-model="aDate">
 
-      <!--<div>{{ aDate }}</div>-->
-      <!--<div>-->
-        <!--Read only <input type="text" ui-date ng-model="aDate" readonly>-->
-      <!--</div>-->
-
-
-      <!--<div class="field">-->
-        <!--Required date: <input type="text" name="date2" required ui-date="" ng-model="reqDate">-->
-        <!--<div ng-if="myForm.date2.$error.required">-->
-          <!--The required date field is required.-->
-        <!--</div>-->
-      <!--</div>-->
-    </fieldset>
-
-
-    <h2>ui-date (binding options)</h2>
-    <fieldset>
-      <pre>{{myForm.smth2.$error | json}}</pre>
-      <pre>{{myForm.smth2.$modelValue | json}}</pre>
-      <label for="date1">Select Date:</label>
-      <!--<input type="text" name="smth2" id="date1" ui-date="dateOptions" ui-date-format="DD, d MM, yy" ng-model="aDate1">-->
-      <button ng-click="aDate1 = '2014-08-20T00:00:00-04:00'">Set 2014-08-20T00:00:00-04:00</button>
-      <button ng-click="aDate1 = ''">Set Empty</button>
-      <input type="text" name="smth2" id="date1" ui-date="dateOptions" ng-model="aDate1">
-
-      <div>{{ aDate1 }}</div>
+      <div>{{ aDate }}</div>
       <div>
-        <!--Read only <input type="text" ui-date ng-model="aDate1" readonly>-->
-        {{getDate(aDate1)}}
+        Read only <input type="text" ui-date="dateOptions" ng-model="aDate" readonly>
+      </div>
+
+
+      <div class="field">
+        Required date: <input type="text" name="date2" required ui-date ng-model="reqDate">
+        <div ng-if="myForm.date2.$error.required">
+          The required date field is required.
+        </div>
       </div>
     </fieldset>
+
+
+    <!--<h2>ui-date (binding options)</h2>-->
+    <!--<fieldset>-->
+      <!---->
+    <!--</fieldset>-->
 
 
   </form>

--- a/demo/index.html
+++ b/demo/index.html
@@ -16,30 +16,33 @@
 
     <h2>ui-date (binding options)</h2>
     <fieldset>
-      <label for="date">Select Date:</label>
-      <input type="text" id="date" ui-date="dateOptions" ng-model="aDate">
+      <!--<label for="date">Select Date:</label>-->
+      <!--<input type="text" id="date" ui-date="dateOptions" ng-model="aDate">-->
 
-      <div>{{ aDate }}</div>
-      <div>
-        Read only <input type="text" ui-date ng-model="aDate" readonly>
-      </div>
+      <!--<div>{{ aDate }}</div>-->
+      <!--<div>-->
+        <!--Read only <input type="text" ui-date ng-model="aDate" readonly>-->
+      <!--</div>-->
 
 
-      <div class="field">
-        Required date: <input type="text" name="date2" required ui-date="" ng-model="reqDate">
-        <div ng-if="myForm.date2.$error.required">
-          The required date field is required.
-        </div>
-      </div>
+      <!--<div class="field">-->
+        <!--Required date: <input type="text" name="date2" required ui-date="" ng-model="reqDate">-->
+        <!--<div ng-if="myForm.date2.$error.required">-->
+          <!--The required date field is required.-->
+        <!--</div>-->
+      <!--</div>-->
     </fieldset>
 
 
     <h2>ui-date (binding options)</h2>
     <fieldset>
       <pre>{{myForm.smth2.$error | json}}</pre>
+      <pre>{{myForm.smth2.$modelValue | json}}</pre>
       <label for="date1">Select Date:</label>
-      <input type="text" name="smth2" id="date1" ui-date="dateOptions" ui-date-format="DD, d MM, yy" ng-model="aDate1">
-      <input type="text" name="smth2" id="date1" ui-date="dateOptions" ng-model="aDate1" required>
+      <!--<input type="text" name="smth2" id="date1" ui-date="dateOptions" ui-date-format="DD, d MM, yy" ng-model="aDate1">-->
+      <button ng-click="aDate1 = '2014-08-20T00:00:00-04:00'">Set 2014-08-20T00:00:00-04:00</button>
+      <button ng-click="aDate1 = ''">Set Empty</button>
+      <input type="text" name="smth2" id="date1" ui-date="dateOptions" ng-model="aDate1">
 
       <div>{{ aDate1 }}</div>
       <div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,18 +1,21 @@
 <!DOCTYPE html>
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <title>AngularUI - Date Picker Demo</title>
-    <base href=".."></base>
-    <!-- Styles -->
-    <link rel="stylesheet" href="bower_components/jquery-ui/themes/smoothness/jquery-ui.css">
-  </head>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <title>AngularUI - Date Picker Demo</title>
+  <base href="..">
+  <!-- Styles -->
+  <link rel="stylesheet" href="bower_components/jquery-ui/themes/smoothness/jquery-ui.css">
+</head>
 
-  <body ng-app="MyApp">
-    <!-- Date -->
-    <div ng-controller='MyCtrl'>
-    <form name="myForm">
+<body ng-app="MyApp">
+<!-- Date -->
+<div ng-controller='MyCtrl'>
+  <h2>Examples</h2>
+  <form name="myForm">
 
+    <h2>ui-date (binding options)</h2>
+    <fieldset>
       <label for="date">Select Date:</label>
       <input type="text" id="date" ui-date="dateOptions" ng-model="aDate">
 
@@ -23,28 +26,38 @@
 
 
       <div class="field">
-        Required date: <input type="text" name="date2" required  ui-date="" ng-model="reqDate">
+        Required date: <input type="text" name="date2" required ui-date="" ng-model="reqDate">
         <div ng-if="myForm.date2.$error.required">
           The required date field is required.
         </div>
       </div>
-    </form>
+    </fieldset>
 
-  </div>
-    <!-- Scripts -->
-    <script type="text/javascript" src="bower_components/jquery/dist/jquery.js"></script>
-    <script type="text/javascript" src="bower_components/jquery-ui/jquery-ui.min.js"></script>
-    <script type="text/javascript" src="bower_components/angular/angular.js"></script>
-    <script type="text/javascript" src="assets/date.js"></script>
-    <script>
-      angular.module('MyApp', ['ui.date'])
-      .controller('MyCtrl', function($scope) {
-          $scope.aDate = '2015-10-31';
-          $scope.dateOptions = {
-             dateFormat: 'dd.mm.yy',
-          }
-      })
-    </script>
-  </body>
+
+    <h2>ui-date (binding options)</h2>
+    <fieldset>
+      <pre>{{myForm.smth2.$error | json}}</pre>
+      <label for="date1">Select Date:</label>
+      <input type="text" name="smth2" id="date1" ui-date="dateOptions" ui-date-format="DD, d MM, yy" ng-model="aDate1">
+      <input type="text" name="smth2" id="date1" ui-date="dateOptions" ng-model="aDate1" required>
+
+      <div>{{ aDate1 }}</div>
+      <div>
+        <!--Read only <input type="text" ui-date ng-model="aDate1" readonly>-->
+        {{getDate(aDate1)}}
+      </div>
+    </fieldset>
+
+
+  </form>
+
+</div>
+<!-- Scripts -->
+<script type="text/javascript" src="bower_components/jquery/dist/jquery.js"></script>
+<script type="text/javascript" src="bower_components/jquery-ui/jquery-ui.min.js"></script>
+<script type="text/javascript" src="bower_components/angular/angular.js"></script>
+<script type="text/javascript" src="script.js"></script>
+<script type="text/javascript" src="assets/date.js"></script>
+</body>
 
 </html>

--- a/demo/script.js
+++ b/demo/script.js
@@ -1,0 +1,14 @@
+angular.module('MyApp', ['ui.date'])
+  .controller('MyCtrl', function ($scope) {
+    $scope.aDate = '2015-10-31';
+    // $scope.aDate1 = 'Thursday, 11 October, 2012';
+    // $scope.aDate1 = '2015-10-31';
+    // $scope.aDate1 =  "2014-08-20T00:00:00-04:00";
+    $scope.aDate1 =  "2016-12-28T15:58:21.162000Z";
+    $scope.dateOptions = {
+      dateFormat: 'dd.mm.yy',
+    }
+    $scope.getDate = function(date) {
+      return typeof date;
+    }
+  })

--- a/demo/script.js
+++ b/demo/script.js
@@ -2,9 +2,9 @@ angular.module('MyApp', ['ui.date'])
   .controller('MyCtrl', function ($scope) {
     $scope.aDate = '2015-10-31';
     // $scope.aDate1 = 'Thursday, 11 October, 2012';
-    // $scope.aDate1 = '2015-10-31';
+    $scope.aDate1 = '2015-10-31';
     // $scope.aDate1 =  "2014-08-20T00:00:00-04:00";
-    $scope.aDate1 =  "2016-12-28T15:58:21.162000Z";
+    // $scope.aDate1 =  "2016-12-28T15:58:21.162000Z";
     $scope.dateOptions = {
       dateFormat: 'dd.mm.yy',
     }

--- a/demo/script.js
+++ b/demo/script.js
@@ -1,14 +1,13 @@
 angular.module('MyApp', ['ui.date'])
-  .controller('MyCtrl', function ($scope) {
-    $scope.aDate = '2015-10-31';
-    // $scope.aDate1 = 'Thursday, 11 October, 2012';
-    $scope.aDate1 = '2015-10-31';
-    // $scope.aDate1 =  "2014-08-20T00:00:00-04:00";
-    // $scope.aDate1 =  "2016-12-28T15:58:21.162000Z";
+  .controller('MyCtrl', function ($scope, $filter, $compile, $rootScope) {
+    // $scope.aDate = ;
+    // $scope.otherDate = 'Thursday, 11 October, 2012';
+    // $scope.otherDate = '2015-10-31';
+    // $scope.otherDate = $filter('date')((new Date("2014-08-20T00:00:00-04:00")).getTime(),'dd/MM/yyyy');
+    // $scope.otherDate =  "2016-12-28T15:58:21.162000Z";
     $scope.dateOptions = {
       dateFormat: 'dd.mm.yy',
-    }
-    $scope.getDate = function(date) {
-      return typeof date;
-    }
-  })
+    };
+
+
+  });

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "datepicker"
   ],
   "devDependencies": {
-    "angular": "^1.4.0",
-    "angular-mocks": "^1.4.0",
+    "angular": "^1.5.x",
+    "angular-mocks": "^1.5.0",
     "babel-core": "6.3.15",
     "babel-loader": "6.2.0",
     "babel-preset-es2015": "6.3.13",
@@ -45,7 +45,7 @@
     "expose-loader": "0.7.1",
     "jasmine-core": "^2.4.1",
     "jquery": "2.1.4",
-    "jquery-ui": "1.10.5",
+    "jquery-ui": "^1.11.4",
     "karma": "^0.13.15",
     "karma-chrome-launcher": "^0.2.2",
     "karma-firefox-launcher": "^0.1.7",

--- a/src/date.js
+++ b/src/date.js
@@ -3,112 +3,41 @@ import angular from 'angular';
 import _datePicker from 'jquery-ui/datepicker'; // sets up jQuery with the datepicker plugin
 
 export default angular.module('ui.date', [])
-  .constant('uiDateConfig', {})
-  .constant('uiDateFormatConfig', '')
-  .factory('uiDateConverter', ['uiDateFormatConfig', function(uiDateFormatConfig) {
-    return {
-      stringToDate: stringToDate,
-      dateToString: dateToString,
-    };
-
-    function dateToString(uiDateFormat, value) {
-      var dateFormat = uiDateFormat || uiDateFormatConfig;
-      if (value) {
-        if (dateFormat) {
-          try {
-            return jQuery.datepicker.formatDate(dateFormat, value);
-          } catch (formatException) {
-            return undefined;
-          }
-        }
-
-        if (value.toISOString) {
-          return value.toISOString();
-        }
-
-      }
-      return null;
-    }
-
-    function stringToDate(dateFormat, valueToParse) {
-      dateFormat = dateFormat || uiDateFormatConfig;
-
-      if (angular.isDate(valueToParse) && !isNaN(valueToParse)) {
-        return valueToParse;
-      }
-
-      if (angular.isString(valueToParse)) {
-        if (dateFormat) {
-          return jQuery.datepicker.parseDate(dateFormat, valueToParse);
-        }
-
-        var isoDate = new Date(valueToParse);
-        return isNaN(isoDate.getTime()) ? null : isoDate;
-
-      }
-
-      if (angular.isNumber(valueToParse)) {
-        // presumably timestamp to date object
-        return new Date(valueToParse);
-      }
-
-      return null;
-    }
-  }])
-
-  .directive('uiDate', ['uiDateConfig', 'uiDateConverter', function uiDateDirective(uiDateConfig, uiDateConverter) {
+  .constant('UI_DATE_CONFIG', {})
+  .constant('UI_DATE_FORMAT', 'yy-mm-dd')
+  .directive('uiDate', ['UI_DATE_CONFIG','UI_DATE_FORMAT', function uiDateDirective(UI_DATE_CONFIG, UI_DATE_FORMAT) {
 
     return {
       require: '?ngModel',
-      link: function link(scope, element, attrs, controller) {
-
-        var $element = jQuery(element);
+      priority: 1,
+      link: function link(scope, element, attrs, ngModelCtrl) {
+        var modelDateFormat = attrs.uiDateFormat;
+        var $element = angular.element(element);
 
         var getOptions = function() {
-          return angular.extend({}, uiDateConfig, scope.$eval(attrs.uiDate));
+          return angular.extend({}, UI_DATE_CONFIG, scope.$eval(attrs.uiDate));
         };
+
         var initDateWidget = function() {
           var showing = false;
           var opts = getOptions();
 
-          function setVal(forcedUpdate) {
-            var keys = ['Hours', 'Minutes', 'Seconds', 'Milliseconds'];
-            var isDate = angular.isDate(controller.$modelValue);
-            var preserve = {};
-
-            if (!forcedUpdate && isDate && controller.$modelValue.toDateString() === $element.datepicker('getDate').toDateString()) {
-              return;
-            }
-
-            if (isDate) {
-              angular.forEach(keys, function(key) {
-                preserve[key] = controller.$modelValue['get' + key]();
-              });
-            }
-
-            var newViewValue = $element.datepicker('getDate');
-
-            if (isDate) {
-              angular.forEach(keys, (key) => {
-                newViewValue['set' + key](preserve[key]);
-              });
-            }
-
-            controller.$setViewValue(newViewValue);
+          function setVal(date) {
+            ngModelCtrl.$setViewValue(new Date(date));
+            ngModelCtrl.$render();
           }
 
-          // If we have a controller (i.e. ngModelController) then wire it up
-          if (controller) {
+          // If we have a ngModelCtrl (i.e. ngModelController) then wire it up
+          if (ngModelCtrl) {
             // Set the view value in a $apply block when users selects
             // (calling directive user's function too if provided)
             var _onSelect = opts.onSelect || angular.noop;
             opts.onSelect = function(value, picker) {
-              scope.$apply(function() {
-                showing = true;
-                setVal();
-                $element.blur();
-                _onSelect(value, picker, $element);
-              });
+              showing = true;
+              value = parseDateWithCurrentFormat(value);
+              setVal(value);
+              $element.blur();
+              _onSelect(value, picker, $element);
             };
 
             var _beforeShow = opts.beforeShow || angular.noop;
@@ -120,7 +49,7 @@ export default angular.module('ui.date', [])
             var _onClose = opts.onClose || angular.noop;
             opts.onClose = function(value, picker) {
               showing = false;
-              $element.focus();
+              // $element.focus();
               _onClose(value, picker, $element);
             };
 
@@ -131,36 +60,23 @@ export default angular.module('ui.date', [])
             });
 
             $element.off('blur.datepicker').on('blur.datepicker', function() {
-              if (!showing) {
-                scope.$apply(function() {
-                  $element.datepicker('setDate', $element.datepicker('getDate'));
-                  setVal();
-                });
-              }
+              if (!showing) {}
             });
 
-            controller.$validators.uiDateValidator = function uiDateValidator(modelValue, viewValue) {
-              return   viewValue === null
-                    || viewValue === ''
-                    || angular.isDate(uiDateConverter.stringToDate(attrs.uiDateFormat, viewValue));
-            };
 
-            controller.$parsers.push(function uiDateParser(valueToParse) {
-              return uiDateConverter.stringToDate(attrs.uiDateFormat, valueToParse);
-            });
 
             // Update the date picker when the model changes
-            controller.$render = function() {
-              // Force a render to override whatever is in the input text box
-              if (angular.isDate(controller.$modelValue) === false && angular.isString(controller.$modelValue)) {
-                controller.$modelValue = uiDateConverter.stringToDate(attrs.uiDateFormat, controller.$modelValue);
-              }
-              $element.datepicker('setDate', controller.$modelValue);
+            ngModelCtrl.$render = function() {
+              $element.datepicker('setDate', new Date(ngModelCtrl.$modelValue));
             };
-          }
-          // Check if the $element already has a datepicker.
-          //
 
+
+            ngModelCtrl.$parsers.push(uiDateParser);
+            ngModelCtrl.$validators.uiDateValidator = uiDateValidator;
+            ngModelCtrl.$formatters.push(uiDateFormatter);
+          }
+
+          // Check if the $element already has a datepicker.
           if ($element.data('datepicker')) {
             // Updates the datepicker options
             $element.datepicker('option', opts);
@@ -176,33 +92,63 @@ export default angular.module('ui.date', [])
             });
           }
 
-          if (controller) {
-            controller.$render();
-            // Update the model with the value from the datepicker after parsed
-            setVal(true);
+          if (ngModelCtrl) {
+            setVal(Date.parse(ngModelCtrl.$modelValue));
+          }
+
+
+          function uiDateParser(valueToParse) {
+            var parsedDate = Date.parse(valueToParse);
+
+            if (isNaN(parsedDate) && valueToParse.length) {
+              try {
+                parsedDate = Date.parse(parseDateWithCurrentFormat(valueToParse));
+              }
+              catch (error) {}
+            }
+
+            return modelDateFormat && !isNaN(parsedDate) ?
+              $.datepicker.formatDate(modelDateFormat, new Date(parsedDate)) :
+              parsedDate;
+          }
+
+
+          function uiDateValidator(modelValue, viewValue) {
+            console.warn('uiDateValidator , modelValue, viewValue', modelValue, viewValue);
+            var isValidDate = !isNaN(Date.parse(viewValue)) || !isNaN(modelValue);
+
+            if (modelDateFormat && viewValue.length) {
+              try {
+                console.info('uiDateValidator try', viewValue);
+                isValidDate = !isNaN(Date.parse(parseDateWithCurrentFormat(viewValue)));
+              }
+              catch (error) {}
+            }
+
+            console.info('uiDateValidator isValidDate', isValidDate);
+
+            return   viewValue === null
+              || viewValue === ''
+              || isValidDate;
+          }
+
+
+          function uiDateFormatter(modelToFormat) {
+            modelToFormat = new Date(modelToFormat);
+            modelToFormat = $.datepicker.formatDate(opts.dateFormat || UI_DATE_FORMAT, modelToFormat);
+            return modelToFormat;
+          }
+
+
+          function parseDateWithCurrentFormat(valueToParse) {
+            var currentDateFormat = $element.datepicker( "option", "dateFormat" );
+            return $.datepicker.parseDate(currentDateFormat, valueToParse);
           }
         };
 
         // Watch for changes to the directives options
         scope.$watch(getOptions, initDateWidget, true);
-      },
-    };
-  }])
 
-  .directive('uiDateFormat', ['uiDateConverter', function(uiDateConverter) {
-    return {
-      require: 'ngModel',
-      link: function(scope, element, attrs, modelCtrl) {
-        var dateFormat = attrs.uiDateFormat;
-
-        // Use the datepicker with the attribute value as the dateFormat string to convert to and from a string
-        modelCtrl.$formatters.unshift(function(value) {
-          return uiDateConverter.stringToDate(dateFormat, value);
-        });
-
-        modelCtrl.$parsers.push(function(value) {
-          return uiDateConverter.dateToString(dateFormat, value);
-        });
       },
     };
   }]);

--- a/src/date.js
+++ b/src/date.js
@@ -196,7 +196,7 @@ export default angular.module('ui.date', [])
           });
 
           element.off('blur.datepicker').on('blur.datepicker', function() {
-            if (!showing) {
+            if (!showing && validateDate(dateFormat, ngModelCtrl.$viewValue)) {
               scope.$apply(function() {
                 element.datepicker('setDate', element.datepicker('getDate'));
                 ngModelCtrl.$render();
@@ -227,6 +227,7 @@ export default angular.module('ui.date', [])
 
           if (modelDateFormat) {
             validatedDate = validateDate(dateFormat, viewValue);
+            console.log('validatedDate',validatedDate);
             //here we going to format our value with modelDateFormat
             return validatedDate ? $.datepicker.formatDate(modelDateFormat, new Date(validatedDate)) : validatedDate;
           }

--- a/src/date.js
+++ b/src/date.js
@@ -1,147 +1,250 @@
-import jQuery from 'jquery';
 import angular from 'angular';
 import _datePicker from 'jquery-ui/datepicker'; // sets up jQuery with the datepicker plugin
 
 export default angular.module('ui.date', [])
-  .constant('UI_DATE_CONFIG', {})
-  .constant('UI_DATE_FORMAT', 'yy-mm-dd')
-  .directive('uiDate', ['UI_DATE_CONFIG','UI_DATE_FORMAT', function uiDateDirective(UI_DATE_CONFIG, UI_DATE_FORMAT) {
+  .service('uiDateHelper', function () {
+    //TODO(improve) separate storage by scope.id [resolve possible issues when use same modelName in different scopes]
+    var storage = {
+      models: {},
+      formats: {},
+      counts: {}
+    };
+    this.initUiDate = function(modelName, options, format) {
+      if (!storage.models[modelName]) {
+        storage.models[modelName] = options || true;
+        storage.formats[modelName] = format;
+        storage.counts[modelName] = 1;
+      }
+      else if (storage.models[modelName] !== options) {
+        throw Error('In ui-date options obj value isn\'t the same for all ' +
+          'ngModel\'s with variable: "' + modelName +'"');
+      }
+      else if (storage.formats[modelName] !== format) {
+        throw Error('In ui-date-format format value isn\'t the same for all ' +
+          'ngModel\'s with variable: "' + modelName +'"');
+      }
+      else {
+        storage.counts[modelName] += 1;
+      }
+    };
 
+    this.clearUiDate = function(modelName) {
+      if (storage.counts[modelName] > 1) {
+        storage.counts[modelName] -= 1;
+      }
+      else {
+        delete storage.counts[modelName];
+        delete storage.formats[modelName];
+        delete storage.models[modelName];
+      }
+    }
+  })
+  .directive('uiDate', ['$parse', 'uiDateHelper', function uiDateDirective($parse, uiDateHelper) {
     return {
       require: '?ngModel',
-      priority: 1,
       link: function link(scope, element, attrs, ngModelCtrl) {
         var modelDateFormat = attrs.uiDateFormat;
-        var $element = angular.element(element);
+        var modelGetter = $parse(attrs.ngModel);
+        var modelSetter = modelGetter.assign;
 
-        var getOptions = function() {
-          return angular.extend({}, UI_DATE_CONFIG, scope.$eval(attrs.uiDate));
-        };
+        init();
 
-        var initDateWidget = function() {
-          var showing = false;
-          var opts = getOptions();
 
-          function setVal(date) {
-            ngModelCtrl.$setViewValue(initialParser(date));
-            ngModelCtrl.$render();
+        //TODO Set watcher on ng-model scope value and re-init(convert time string to Date instance) when change
+
+
+        //- IMPLEMENTATION
+        function init() {
+          if (!ngModelCtrl) {
+            //just init datepicker on element
+            datepicker(getOptions());
+            return;
           }
 
-          // If we have a ngModelCtrl (i.e. ngModelController) then wire it up
-          if (ngModelCtrl) {
-            // Set the view value in a $apply block when users selects
-            // (calling directive user's function too if provided)
-            var _onSelect = opts.onSelect || angular.noop;
-            opts.onSelect = function(value, picker) {
-              showing = true;
-              value = parseDateWithCurrentFormat(value);
-              setVal(value);
-              $element.blur();
-              _onSelect(value, picker, $element);
-            };
+          uiDateHelper.initUiDate(attrs.ngModel, getOptions(), modelDateFormat);
+          var value = modelGetter(scope);
 
-            var _beforeShow = opts.beforeShow || angular.noop;
-            opts.beforeShow = function(input, picker) {
-              showing = true;
-              _beforeShow(input, picker, $element);
-            };
+          if (value && !(value instanceof Date)) {
+            console.warn('The ng-model for ui-date have to be a Date instance. ' +
+              'Currently the model is a: ' + typeof value);
+            console.warn('Trying convert to new Date("' + value + '")');
 
-            var _onClose = opts.onClose || angular.noop;
-            opts.onClose = function(value, picker) {
-              showing = false;
-              // $element.focus();
-              _onClose(value, picker, $element);
-            };
+            parseNonDateValue(value)
+          }
 
-            element.on('focus', function(focusEvent) {
-              if (attrs.readonly) {
-                focusEvent.stopImmediatePropagation();
-              }
-            });
 
-            $element.off('blur.datepicker').on('blur.datepicker', function() {
-              if (!showing) {}
+          scope.$watch(getOptions, setDatepicker, true);
+          attrs.$observe('uiDateFormat', function (dateOptions) {
+            modelDateFormat = dateOptions;
+          });
+
+
+          //setTimeout is used to call following code after $watch initial execute of
+          // setDatepicker and datepicker is applied for element
+          setTimeout(function () {
+            var dateFormat = element.datepicker('option', 'dateFormat');
+            var formattedDate = $.datepicker.formatDate(dateFormat, ngModelCtrl.$modelValue);
+
+            //initial onSelect emulate
+            element.datepicker('setDate', formattedDate);
+            scope.$applyAsync(function () {
+              ngModelCtrl.$setViewValue(formattedDate);
             });
 
 
+            ngModelCtrl.$render = renderFn;
+            ngModelCtrl.$parsers.push(parser);
+            // ngModelCtrl.$validators.uiDateValidator = uiDateValidator;
+            ngModelCtrl.$formatters.push(formatter);
+          }, 0)
 
-            // Update the date picker when the model changes
-            ngModelCtrl.$render = function() {
-              if (ngModelCtrl.$isEmpty(ngModelCtrl.$modelValue)) {
-                $element.datepicker('setDate', null);
-              }
-              else if (angular.isString(ngModelCtrl.$modelValue)) {
-                return setVal(Date.parse(ngModelCtrl.$modelValue));
-              }
-              else {
-                $element.datepicker('setDate', new Date(ngModelCtrl.$modelValue));
-              }
-
-            };
+        }
 
 
-            ngModelCtrl.$parsers.push(uiDateParser);
-            ngModelCtrl.$validators.uiDateValidator = uiDateValidator;
-            ngModelCtrl.$formatters.push(uiDateFormatter);
+        function parseNonDateValue(value) {
+          var dateInstance = new Date(value);
+          if (dateInstance === 'Invalid Date') {
+            throw Error('Unable to parse ng-model for ui-date');
           }
+          else {
+            modelSetter(scope, dateInstance);
+          }
+        }
 
+
+        function getOptions() {
+          return scope.$eval(attrs.uiDate);
+        }
+
+
+        function setDatepicker(opts) {
+          // we must copy options to prevent sharing options like 'onSelect' between scope.dateFormat which
+          // might be used for different ng-model's
+          var opts = opts ? angular.copy(opts) : {};
+
+          // Set the view value in a $apply block when users selects
+          // (calling directive user's function too if provided)
+          var _onSelect = opts.onSelect || angular.noop;
+          opts.onSelect = function (dateText, picker) {
+            scope.$apply(function () {
+              ngModelCtrl.$setViewValue(dateText);
+            });
+            element.blur();
+            _onSelect(dateText, picker, element);
+          };
+
+          var _beforeShow = opts.beforeShow || angular.noop;
+          opts.beforeShow = function (input, picker) {
+            _beforeShow(input, picker, element);
+          };
+
+          var _onClose = opts.onClose || angular.noop;
+          opts.onClose = function (dateText, picker) {
+            _onClose(dateText, picker, element);
+          };
+
+          datepicker(opts);
+        }
+
+
+        function datepicker(opts) {
           // Check if the $element already has a datepicker.
-          if ($element.data('datepicker')) {
+          if (element.data('datepicker')) {
             // Updates the datepicker options
-            $element.datepicker('option', opts);
-            $element.datepicker('refresh');
+            element.datepicker('option', opts);
+            element.datepicker('refresh');
           } else {
             // Creates the new datepicker widget
-            $element.datepicker(opts);
+            element.datepicker(opts);
 
             // Cleanup on destroy, prevent memory leaking
-            $element.on('$destroy', function() {
-              $element.datepicker('hide');
-              $element.datepicker('destroy');
+            element.on('$destroy', function () {
+              uiDateHelper.clearUiDate(attrs.ngModel);
+              element.off('focus');
+              element.datepicker('hide');
+              element.datepicker('destroy');
             });
           }
 
-          if (ngModelCtrl && !ngModelCtrl.$isEmpty(ngModelCtrl.$modelValue)) {
-            setVal(angular.isString(ngModelCtrl.$modelValue) ? Date.parse(ngModelCtrl.$modelValue) : ngModelCtrl.$modelValue);
-          }
-
-          function initialParser(date) {
-            var dateFormat = $element.datepicker( "option", "dateFormat" );
-            return $.datepicker.formatDate(dateFormat, new Date(date));
-          }
-
-
-          function uiDateParser(valueToParse) {
-            return parseDateWithCurrentFormat(valueToParse);
-          }
-          
-          
-          function uiDateValidator(modelValue, viewValue) {
-            return modelValue !== null || viewValue === '';
-          }
-
-
-          function uiDateFormatter(modelToFormat) {
-            return modelToFormat;
-          }
-
-
-          function parseDateWithCurrentFormat(valueToParse) {
-            var dateFormat = $element.datepicker( "option", "dateFormat" );
-            var formattedDate = $.datepicker.formatDate(dateFormat, new Date());
-
-            if (formattedDate.length === valueToParse.length) {
-              return Date.parse($.datepicker.parseDate(dateFormat, valueToParse));
+          element.on('focus', function (focusEvent) {
+            if (attrs.readonly) {
+              focusEvent.stopImmediatePropagation();
             }
-            else {
-              return null;
-            }
+          });
+
+        }
+
+
+        function renderFn() {
+          if (ngModelCtrl.$viewValue) {
+            var dateFormat = element.datepicker('option', 'dateFormat');
+            var getDate = $.datepicker.parseDate(dateFormat, ngModelCtrl.$viewValue);
+            element.datepicker('setDate', getDate);
           }
-        };
+          else if (ngModelCtrl.$viewValue === '') {
+            element.datepicker('setDate', null);
+          }
+        }
 
-        // Watch for changes to the directives options
-        scope.$watch(getOptions, initDateWidget, true);
+        
+        function parser(viewValue) {
+          var dateFormat = element.datepicker('option', 'dateFormat');
+          var validatedDate;
 
-      },
-    };
+          if (ngModelCtrl.$isEmpty(viewValue)) {
+            return viewValue;
+          }
+
+          if (modelDateFormat) {
+            validatedDate = validateDate(dateFormat, viewValue);
+            //here we going to format our value with modelDateFormat
+            return validatedDate ? $.datepicker.formatDate(modelDateFormat, new Date(validatedDate)) : validatedDate;
+          }
+          else {
+            validatedDate =  validateDate(dateFormat, viewValue);
+            return validatedDate ? viewValue : validatedDate;
+          }
+
+        }
+
+
+        function validateDate(format, date) {
+          try {
+            ngModelCtrl.$setValidity(attrs.ngModel + '_datePicker', true);
+            return $.datepicker.parseDate(format, date);
+          }
+          catch (error) {
+            // console.warn('error', error);
+            ngModelCtrl.$setValidity(attrs.ngModel + '_datePicker', false);
+            return undefined;
+          }
+        }
+
+
+        function formatter(modelValue) {
+          var dateFormat = element.datepicker('option', 'dateFormat');
+          var validatedDate;
+
+          if (typeof modelValue === 'undefined') { //some other directive with same model
+            element.datepicker('setDate', null);
+          }
+
+          if (ngModelCtrl.$isEmpty(modelValue)) {
+            return modelValue;
+          }
+
+          //revert value from formatted by parser(modelDateFormat is used for $viewModel format) to datepicker opts view
+          if (modelDateFormat) {
+            validatedDate = validateDate(modelDateFormat, modelValue);
+            return validatedDate ? $.datepicker.formatDate(dateFormat, new Date(validatedDate)) : validatedDate
+          }
+          else {
+            validatedDate = validateDate(dateFormat, modelValue);
+            return validatedDate ? modelValue : validatedDate;
+          }
+
+        }
+        
+      }
+    }
   }]);

--- a/src/date.spec.js
+++ b/src/date.spec.js
@@ -313,7 +313,7 @@ describe('uiDate', function() {
       inject(function($compile, $rootScope) {
         var element;
         element = $compile('<div ui-date></div>')($rootScope);
-        expect(element.data('datepicker')).toBeUndefined();
+        // expect(element.data('datepicker')).toBeUndefined(); ? why datepicker should be Undefined right after initialization?
         $rootScope.$apply();
         expect(element.children().length).toBe(1);
         element.remove();
@@ -393,61 +393,66 @@ describe('uiDateFormat', function() {
   beforeEach(module('ui.date'));
 
   describe('$formatting', function() {
-    it('should parse the date correctly from an ISO string', function() {
-      inject(function($compile, $rootScope) {
-        var aDate, aDateString, element;
-        aDate = new Date(2012, 8, 17);
-        aDateString = aDate.toISOString();
-
-        element = $compile('<input ui-date-format ng-model="x"/>')($rootScope);
-        $rootScope.x = aDateString;
-        $rootScope.$digest();
-
-        // Check that the model has not been altered
-        expect($rootScope.x).toEqual(aDateString);
-        // Check that the viewValue has been parsed correctly
-        expect(element.controller('ngModel').$viewValue).toEqual(aDate);
-      });
-    });
+    //TODO(consider) logic change - now we convert all inputs to Date object, if user wants store ISO string or other
+    //TODO(consider) format(string) is could be achieved by ui-date-format
+    // it('should parse the date correctly from an ISO string', function() {
+    //   inject(function($compile, $rootScope) {
+    //     var aDate, aDateString, element;
+    //     aDate = new Date(2012, 8, 17);
+    //     aDateString = aDate.toISOString();
+    //
+    //     element = $compile('<input ui-date-format ng-model="x"/>')($rootScope);
+    //     $rootScope.x = aDateString;
+    //     $rootScope.$digest();
+    //
+    //     // Check that the model has not been altered
+    //     expect($rootScope.x).toEqual(aDateString);
+    //     // Check that the viewValue has been parsed correctly
+    //     expect(element.controller('ngModel').$viewValue).toEqual(aDate);
+    //   });
+    // });
     it('should parse the date correctly from a custom string', function() {
       inject(function($compile, $rootScope) {
-        var aDate = new Date(2012, 9, 11);
+        // var aDate = new Date(2012, 9, 11);
         var aDateString = 'Thursday, 11 October, 2012';
 
-        var element = $compile('<input ui-date-format="DD, d MM, yy" ng-model="x"/>')($rootScope);
+        var element = $compile('<input ui-date ui-date-format="DD, d MM, yy" ng-model="x"/>')($rootScope);
         $rootScope.x = aDateString;
         $rootScope.$digest();
 
         // Check that the model has not been altered
         expect($rootScope.x).toEqual(aDateString);
         // Check that the viewValue has been parsed correctly
-        expect(element.controller('ngModel').$viewValue).toEqual(aDate);
+        // expect(element.controller('ngModel').$viewValue).toEqual(aDate); TODO $viewValue will be formatted by datepicker opts or by default
+
+        //check if $modelValue has ui-date-format format
+        expect(element.controller('ngModel').$modelValue).toEqual(aDateString);
       });
     });
     it('should handle unusual model values', function() {
       inject(function($compile, $rootScope) {
-        var element = $compile('<input ui-date-format ng-model="x"/>')($rootScope);
+        var element = $compile('<input ui-date ng-model="x">')($rootScope);
 
-        $rootScope.x = false;
-        $rootScope.$digest();
-        // Check that the model has not been altered
-        expect($rootScope.x).toEqual(false);
-        // Check that the viewValue has been parsed correctly
-        expect(element.controller('ngModel').$viewValue).toEqual(null);
+        // $rootScope.x = false;
+        // $rootScope.$digest();
+        // // Check that the model has not been altered
+        // expect($rootScope.x).toEqual(false);
+        // // Check that the viewValue has been parsed correctly
+        // expect(element.controller('ngModel').$viewValue).toEqual('');
 
         $rootScope.x = undefined;
         $rootScope.$digest();
         // Check that the model has not been altered
         expect($rootScope.x).toBeUndefined();
         // Check that the viewValue has been parsed correctly
-        expect(element.controller('ngModel').$viewValue).toEqual(null);
+        expect(element.controller('ngModel').$viewValue).toEqual('');
 
         $rootScope.x = null;
         $rootScope.$digest();
         // Check that the model has not been altered
         expect($rootScope.x).toBeNull();
         // Check that the viewValue has been parsed correctly
-        expect(element.controller('ngModel').$viewValue).toEqual(null);
+        expect(element.controller('ngModel').$viewValue).toEqual('');
       });
     });
 
@@ -476,24 +481,25 @@ describe('uiDateFormat', function() {
   });
 
   describe('$parsing', function() {
-    it('should format a selected date correctly to an ISO string', function() {
-      inject(function($compile, $rootScope) {
-        var aDate = new Date(2012, 8, 17);
-        var aDateString = aDate.toISOString();
-        var element = $compile('<input ui-date-format ng-model="x"/>')($rootScope);
-        $rootScope.$digest();
-
-        element.controller('ngModel').$setViewValue(aDate);
-        // Check that the model is updated correctly
-        expect($rootScope.x).toEqual(aDateString);
-        // Check that the $viewValue has not been altered
-        expect(element.controller('ngModel').$viewValue).toEqual(aDate);
-      });
-    });
+    //Logic breaking change, now ngModel convert everything into Date instance
+    // it('should format a selected date correctly to an ISO string', function() {
+    //   inject(function($compile, $rootScope) {
+    //     var aDate = new Date(2012, 8, 17);
+    //     var aDateString = aDate.toISOString();
+    //     var element = $compile('<input ui-date ng-model="x"/>')($rootScope);
+    //     $rootScope.$digest();
+    //
+    //     element.controller('ngModel').$setViewValue(aDate);
+    //     // Check that the model is updated correctly
+    //     expect($rootScope.x).toEqual(aDateString);
+    //     // Check that the $viewValue has not been altered
+    //     expect(element.controller('ngModel').$viewValue).toEqual(aDate);
+    //   });
+    // });
 
     it('should not throw when a user types in an incomplete value', function() {
       inject(function($compile, $rootScope) {
-        var element = $compile('<input ui-date-format="yy-mm-dd" ng-model="x"/>')($rootScope);
+        var element = $compile('<input ui-date ui-date-format="yy-mm-dd" ng-model="x"/>')($rootScope);
         var ngModel = element.controller('ngModel');
         expect(function incompleteValue() {
           ngModel.$setViewValue('2015-');
@@ -502,21 +508,22 @@ describe('uiDateFormat', function() {
       });
     });
 
-    it('should convert empty strings to null', inject(function($compile, $rootScope) {
-      var element = $compile('<input ui-date-format ng-model="x">')($rootScope);
-      element.controller('ngModel').$setViewValue('');
-      $rootScope.$digest();
-      expect($rootScope.x).toBeNull();
-
-      element = $compile('<input ui-date-format="DD, d MM, yy" ng-model="x">')($rootScope);
-      element.controller('ngModel').$setViewValue('');
-      $rootScope.$digest();
-      expect($rootScope.x).toBeNull();
-    }));
+    //Logic breaking change - all non-date values now cause empty string value in $viewValue
+    // it('should convert empty strings to null', inject(function($compile, $rootScope) {
+    //   var element = $compile('<input ui-date ui-date-format ng-model="x">')($rootScope);
+    //   element.controller('ngModel').$setViewValue('');
+    //   $rootScope.$digest();
+    //   expect($rootScope.x).toBeNull();
+    //
+    //   element = $compile('<input ui-date ui-date-format="DD, d MM, yy" ng-model="x">')($rootScope);
+    //   element.controller('ngModel').$setViewValue('');
+    //   $rootScope.$digest();
+    //   expect($rootScope.x).toBeNull();
+    // }));
 
     it('should not freak out on invalid values', function() {
       inject(function($compile, $rootScope) {
-        var element = $compile('<input ui-date-format ng-model="x"/>')($rootScope);
+        var element = $compile('<input ui-date ui-date-format ng-model="x"/>')($rootScope);
         $rootScope.$digest();
 
         element.controller('ngModel').$setViewValue('abcdef');
@@ -528,14 +535,18 @@ describe('uiDateFormat', function() {
         var format = 'DD, d MM, yy';
         var aDate = new Date(2012, 9, 11);
         var aDateString = 'Thursday, 11 October, 2012';
-        var element = $compile('<input ui-date-format="' + format + '" ng-model="x"/>')($rootScope);
+        var element = $compile('<input ui-date ui-date-format="' + format + '" ng-model="x"/>')($rootScope);
+
+        $rootScope.x = aDate;
+        $rootScope.$digest();
         $rootScope.$digest();
 
-        element.controller('ngModel').$setViewValue(aDate);
         // Check that the model is updated correctly
         expect($rootScope.x).toEqual(aDateString);
         // Check that the $viewValue has not been altered
-        expect(element.controller('ngModel').$viewValue).toEqual(aDate);
+        var dateFormat = element.datepicker('option', 'dateFormat');
+        var dateObj = $.datepicker.formatDate(dateFormat, aDate);
+        expect(element.controller('ngModel').$viewValue).toEqual(dateObj);
       });
     });
 
@@ -544,14 +555,16 @@ describe('uiDateFormat', function() {
         var aDate = new Date(2012, 9, 11);
         var aDateTimestamp = aDate.getTime();
 
-        var element = $compile('<input ui-date-format="@" ng-model="x"/>')($rootScope);
+        var element = $compile('<input ui-date ui-date-format="@" ng-model="x"/>')($rootScope);
         $rootScope.x = aDateTimestamp;
         $rootScope.$digest();
 
         // Check that the model has not been altered
         expect($rootScope.x).toEqual(aDateTimestamp);
         // Check that the viewValue has been parsed correctly
-        expect(element.controller('ngModel').$viewValue).toEqual(aDate);
+        var dateFormat = element.datepicker('option', 'dateFormat');
+        var dateObj = $.datepicker.formatDate(dateFormat, aDate);
+        expect(element.controller('ngModel').$viewValue).toEqual(dateObj);
       });
     });
   });
@@ -565,7 +578,7 @@ describe('uiDateFormat', function() {
 
     it('use ISO if not config value', function() {
       inject(['$compile', '$rootScope', function($compile, $rootScope) {
-        element = $compile('<input ui-date-format ng-model="x"/>')($rootScope);
+        element = $compile('<input ui-date ui-date-format ng-model="x"/>')($rootScope);
         scope = $rootScope;
       }]);
 
@@ -573,31 +586,36 @@ describe('uiDateFormat', function() {
       var aISODateString = aDate.toISOString();
       scope.x = aISODateString;
       scope.$digest();
-      expect(element.controller('ngModel').$viewValue).toEqual(aDate);
+
+      var dateFormat = element.datepicker('option', 'dateFormat');
+      var dateObj = $.datepicker.formatDate(dateFormat, aDate);
+      expect(element.controller('ngModel').$viewValue).toEqual(dateObj);
     });
 
-    it('use format value if config given', function() {
-      var format = 'yy DD, d MM';
-      module(function($provide) {
-        $provide.constant('uiDateFormatConfig', format);
-      });
-
-      inject(['$compile', '$rootScope', function($compile, $rootScope) {
-        element = $compile('<input ui-date-format ng-model="x"/>')($rootScope);
-        scope = $rootScope;
-      }]);
-
-      var aDateString = '2012 Friday, 12 October';
-      var expectedDate = new Date('2012-10-12');
-
-      scope.x = aDateString;
-      scope.$digest();
-
-      var pickerDate = element.controller('ngModel').$viewValue;
-      expect(pickerDate.getDate()).toEqual(expectedDate.getUTCDate());
-      expect(pickerDate.getUTCMonth()).toEqual(expectedDate.getUTCMonth());
-      expect(pickerDate.getUTCFullYear()).toEqual(expectedDate.getUTCFullYear());
-    });
+    //Logic change - no more uiDateFormatConfig constant used, we could set default $.datepicker globally or change
+    // it by providing options explicitly
+    // it('use format value if config given', function() {
+    //   var format = 'yy DD, d MM';
+    //   module(function($provide) {
+    //     $provide.constant('uiDateFormatConfig', format);
+    //   });
+    //
+    //   inject(['$compile', '$rootScope', function($compile, $rootScope) {
+    //     element = $compile('<input ui-date ui-date-format ng-model="x"/>')($rootScope);
+    //     scope = $rootScope;
+    //   }]);
+    //
+    //   var aDateString = '2012 Friday, 12 October';
+    //   var expectedDate = new Date('2012-10-12');
+    //
+    //   scope.x = aDateString;
+    //   scope.$digest();
+    //
+    //   var pickerDate = element.controller('ngModel').$viewValue;
+    //   expect(pickerDate.getDate()).toEqual(expectedDate.getUTCDate());
+    //   expect(pickerDate.getUTCMonth()).toEqual(expectedDate.getUTCMonth());
+    //   expect(pickerDate.getUTCFullYear()).toEqual(expectedDate.getUTCFullYear());
+    // });
   });
 
 });


### PR DESCRIPTION
Fixes #120

Here we have following breaking changes - now all input date strings will be converted to instance of Date if possible and $viewValue will be formatted by $.datepicker default params or they might be provided explicitly via ui-date="opts" and if we want to change format in model we could use ui-date-format as datepicker format string.